### PR TITLE
fix(ci): use only valid parameters for TODO automation

### DIFF
--- a/.github/workflows/auto-issue-creation.yml
+++ b/.github/workflows/auto-issue-creation.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [main, staging, dev]
   workflow_dispatch:
-
 jobs:
   todo-to-issue:
     runs-on: ubuntu-latest
@@ -17,9 +16,8 @@ jobs:
         uses: alstr/todo-to-issue-action@v4.6.9
         with:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INSERT_ISSUE_URLS: "true"
+          REPO: ${{ github.repository }}
           CLOSE_ISSUES: "true"
-          IDENTIFIERS: >
-            [
-              {"name": "TODO", "labels": ["todo", "auto-generated"]}
-            ]
+          AUTO_P: "false"
+          LABEL: "todo,auto-generated"
+          COMMENT_MARKER: "//"

--- a/src/modules/core/hooks/useHomeContent.js
+++ b/src/modules/core/hooks/useHomeContent.js
@@ -87,7 +87,7 @@ export const useAboutContent = () => {
         await new Promise(resolve => setTimeout(resolve, 100));
         setIsLoading(true);
         // TODO: Define Routes - About content management API
-        // Test 2
+        // Test 3
         // Create a API endpoint for dynamic about section content.
         // Backend requirements:
         // - GET /api/content/about (fetch about content)


### PR DESCRIPTION
Removed INSERT_ISSUE_URLS and IDENTIFIERS, added REPO and COMMENT_MARKER parameters. Should now create proper issue titles instead of throwing validation warnings.